### PR TITLE
frog-jump-buffer-default-filter not working

### DIFF
--- a/frog-jump-buffer.el
+++ b/frog-jump-buffer.el
@@ -58,7 +58,7 @@
   "This is the maximum number of buffers to show in the `frog-menu'."
   :type 'number)
 
-(defcustom frog-jump-buffer-default-filter 'frog-jump-buffer-filter-all
+(defcustom frog-jump-buffer-current-filter-function 'frog-jump-buffer-filter-all
   "This is the default filter to use when invoking `frog-jump-buffer'.
 Shows all buffers by default."
   :type 'symbol)
@@ -109,9 +109,6 @@ Each action is a list of the form: (KEY DESCRIPTION FILTER-FUNCTION)."
   (if frog-jump-buffer-use-default-filter-actions
       (append (frog-jump-buffer-default-filter-actions) frog-jump-buffer-filter-actions)
     frog-jump-buffer-filter-actions))
-
-(defvar frog-jump-buffer-current-filter-function frog-jump-buffer-default-filter
-  "This is a placeholder variable for determining which function to filter buffers by.")
 
 (defun frog-jump-buffer-get-current-filter-name ()
   "Get the current filter’s name."


### PR DESCRIPTION
Maybe I'm doing something wrong, but defvar seems to always use the default value of defcustom, which makes setq useless. having only defcustom makes the package work as expected to me.